### PR TITLE
Added the Resume link to the main navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,3 +10,5 @@ main:
     url: "/tags/"
   - title: "Categories"
     url: "/categories/"
+  - title: "Resume"
+    url: "https://github.com/mehul-m-prajapati/Resume/raw/master/Resume.pdf"


### PR DESCRIPTION
Added a new 'Resume' link (to @mehul-m-prajapati current Resume pdf) to the site's main navigation. Fixes #15 